### PR TITLE
Update year using Javascript

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -56,11 +56,12 @@
 <p class="heading"><img alt="Explore Button" id="explore" dir="ltr" height="100" src="asset/button/exploreA.png" width="200" onmousedown="FP_swapImg(1,1,/*id*/'explore',/*url*/'asset/button/exploreC.png')" onmouseout="FP_swapImgRestore()" onmouseover="FP_swapImg(1,1,/*id*/'explore',/*url*/'asset/button/exploreB.png');" onmouseup="FP_swapImgRestore()" class="heading" onclick="FP_goToURL(/*href*/'explore.php');"></p>
 <p class="heading"><img src="asset/logo/LogoText.png" width="242" height="100.5"></p>
 <p><a href="toolbox.php">i wanna be debugging</a></p>
-<p align="right">Copyright (C) 2018-2019 Open Shop Channel Team</p>
+<p align="right" id="copyright_msg">Copyright (C) 2018-{YEAR} Open Shop Channel Team</p>
 </p>
 <p id="test" style="display: none;"></p>
 <script>
     document.getElementById('test').innerHTML = new wiiShop().connecting
+    document.getElementById('copyright_msg').innerHTML = document.getElementById('copyright_msg').innerHTML.replace("{YEAR}", new Date().getFullYear())
 </script>
 <script type="text/javascript" src="/js/wiicore.js"></script>
 <script>


### PR DESCRIPTION
As suggested [here](https://github.com/OpenShopChannel/ShopChannel/commit/2f4ecb70da8dbeae91efb2a412f0f6c49f0f9df1#commitcomment-32147558), this PR makes Javascript change the year automagically! This modification should be applicable everywhere there needs to be a current year displayed.