### PR TITLE
Remove the last remnants of Shemma's Curse.

### DIFF
--- a/public_html/toolbox.php
+++ b/public_html/toolbox.php
@@ -12,7 +12,6 @@
 			<p><a href="download/prodinfo.php">Product Page</a></p>
 			<p><a href="/clubspot/index.php">Club Spot index</a></p>
             <p><a href="/error/list.php">Error List</a></p>
-            <p><a href="/lab">Labs (Directory Listing)</a></p>
             <p><a href="../deploy.php">Deployment & Pull Debug</a></p>
 			<p><a href="debug.php">debugmii</a></p>
 			<p><button onmousedown="sound.playBGM()">play thy bgm</button></p>


### PR DESCRIPTION
This link that used to link to the heart of *Shemma's Curse* was not removed when attempts to remove *Shemma's Curse* was done, and continued to give the project *Shemma's Curse*, albeit a quite tame variant.

This should revive the **Open Shop Channel** project as a whole and take us out of our current dark period.